### PR TITLE
update: 商品詳細ページの調整

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -158,12 +158,15 @@
     text-align: center;
     padding-top: 20px;
     cursor: pointer;
-    p {
+    a {
       font-size: 22px;
       font-family: "游ゴシック体", YuGothic;
+      text-decoration: none;
+      color: rgb(255, 255, 255);
     }
     i {
       font-size: 60px;
+      color: rgb(255, 255, 255);
     }
   }
 }

--- a/app/assets/stylesheets/items/_body.scss
+++ b/app/assets/stylesheets/items/_body.scss
@@ -105,6 +105,9 @@
         padding: 8px 10px;
         background-color: rgb(245, 245, 245);
         cursor: pointer;
+        text-decoration: none;
+        color: #333333;
+        font-weight: bold;
       }
     }
   }
@@ -142,6 +145,7 @@
         display: flex;
         flex-wrap: wrap;
         padding-top: 10px;
+        padding-bottom: 60px;
         &__show {
           width: 18%;
           height: 250px;

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -46,8 +46,10 @@ body {
           flex-direction: column;
           a {
             display: block;
+            color: #0099e8;
             &:nth-child(1) {
             color: #0099e8;
+            text-decoration: none;
             }
           }
           .light-blue {
@@ -67,6 +69,14 @@ body {
             font-size: 16px;
             color: #5ebbe6;
             margin-left: 10px;
+          }
+          i {
+            font-size: 12px;
+            color: #5ebbe6;
+            margin-top: 4px;
+          }
+          .chevron-right {
+            float: left;
           }
         }
         table {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :update, :show, :destroy]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("id DESC").limit(10)
   end
 
   def confirm

--- a/app/views/items/_body.html.haml
+++ b/app/views/items/_body.html.haml
@@ -18,15 +18,63 @@
     .top.body__notice__main
       人気のカテゴリー
     .top.body__notice__select
-      %a レディース
-      %a メンズ
-      %a 家電
-      %a おもちゃ
+      = link_to "レディース", "#ladies-items"
+      = link_to "メンズ", "#mens-items"
+      = link_to "家電", "#electronics-items"
+      = link_to "おもちゃ", "#toys-items"
   .top.body__new
     .top.body__new__item
-      .top.body__new__item__box
+      .top.body__new__item__box#ladies-items
         .top.body__new__item__box__category
-          新着アイテム
+          レディース新着アイテム
+        .top.body__new__item__box__more
+          = link_to "もっと見る ＞", root_path
+      .top.body__new__item__list
+        - @items.each do |item|
+          .top.body__new__item__list__show
+            = link_to "", item_path(item)
+            .top.body__new__item__list__show__image
+              = image_tag(item.images.first.image, size: "184x184")
+              %p
+                ¥#{item.price}
+            .top.body__new__item__list__show__name
+              = item.name
+              .top.body__new__item__list__show__name__opa
+      .top.body__new__item__box#mens-items
+        .top.body__new__item__box__category
+          メンズ新着アイテム
+        .top.body__new__item__box__more
+          = link_to "もっと見る ＞", root_path
+      .top.body__new__item__list
+        - @items.each do |item|
+          .top.body__new__item__list__show
+            = link_to "", item_path(item)
+            .top.body__new__item__list__show__image
+              = image_tag(item.images.first.image, size: "184x184")
+              %p
+                ¥#{item.price}
+            .top.body__new__item__list__show__name
+              = item.name
+              .top.body__new__item__list__show__name__opa
+      .top.body__new__item__box#electronics-items
+        .top.body__new__item__box__category
+          家電新着アイテム
+        .top.body__new__item__box__more
+          = link_to "もっと見る ＞", root_path
+      .top.body__new__item__list
+        - @items.each do |item|
+          .top.body__new__item__list__show
+            = link_to "", item_path(item)
+            .top.body__new__item__list__show__image
+              = image_tag(item.images.first.image, size: "184x184")
+              %p
+                ¥#{item.price}
+            .top.body__new__item__list__show__name
+              = item.name
+              .top.body__new__item__list__show__name__opa
+      .top.body__new__item__box
+        .top.body__new__item__box__category#toys-items
+          おもちゃ新着アイテム
         .top.body__new__item__box__more
           = link_to "もっと見る ＞", root_path
       .top.body__new__item__list

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -37,5 +37,6 @@
               .top.header__box__below__users__member__right
                 = link_to "ログイン", new_user_session_path, class: "member_right"
   .top.syuppin
-    %p出品
-    %i.fas.fa-camera
+    = link_to new_item_path do
+      %p出品
+      %i.fas.fa-camera

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -125,8 +125,8 @@
               に同意したことになります。
           %button{type: "submit", class: "sell__main__content__button__red"}
             出品する
-          %a.sell__main__content__button__gray
-            もどる
+          = link_to "もどる", root_path, class: "sell__main__content__button__gray"
+
   %header.sell__footer
     %ul
       %li

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -25,10 +25,19 @@
               %tr
                 %th カテゴリー
                 %td.item-box-container__item-main-content-clearfix__table__td
+                  = link_to @item.category.parent.parent.name, class: "light-blue__category"
+                  = fas_icon 'chevron-right', class: "chevron-right"
+                  = link_to @item.category.parent.name, class: "light-blue__category"
+                  = fas_icon 'chevron-right', class: "chevron-right"
                   = link_to @item.category.name, class: "light-blue__category"
               %tr
                 %th ブランド
                 %td トリココムデギャルソン
+              -if @item.size
+                %tr
+                  %th 商品のサイズ
+                  %td
+                    = @item.size
               %tr
                 %th 商品の状態
                 %td


### PR DESCRIPTION
# What
商品詳細ページの調整。
トップページの調整。

# Why
紐付く詳細を表示させるため。
見た目をよくするため。

![e671c4f86c3fbdc6cad2ff146f20ff15](https://user-images.githubusercontent.com/57166192/71164850-2be22800-2293-11ea-825d-4b59b071972b.jpg)

<img width="710" alt="113267d58f9bb8ef45035c4cfc84cb15" src="https://user-images.githubusercontent.com/57166192/71164937-43211580-2293-11ea-830a-f5b9d20f7df5.png">

