### PR TITLE
商品購入画面に商品データを表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,6 +6,7 @@ class ItemsController < ApplicationController
   end
 
   def confirm
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -6,18 +6,18 @@
     .confirm.body__top
       購入内容の確認
     .confirm.body__show
-      = image_tag 'steve.jpg', size: '80x80', class: "confirm.body__show__image"
+      = image_tag(@item.images.first.image, size: "80x80", class: "confirm.body__show__image")
       .confirm.body__show__detail
-        %p steve⭐️stay foolish
-        %p ¥18,200 （税込）送料込み
+        %p #{@item.name}
+        %p ¥#{@item.price.to_s(:delimited, delimiter: ',')}（税込）送料込み
     .confirm.body__box
       .confirm.body__box__form
         .confirm.body__box__form__1
           支払い金額
-          %a ¥18,200
+          %a ¥#{@item.price.to_s(:delimited, delimiter: ',')}
           = form_for "" do |f|
             = f.check_box :content, class: 'form__check', id: "form__check"
-            %b ポイントを使用(所持ポイント:po)
+            %b ポイントを使用(所持ポイント:0)
         .confirm.body__box__form__2
           %p 支払い方法
           = link_to "" do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -52,7 +52,7 @@
             = "¥#{@item.price.to_s(:delimited, delimiter: ',')}"
           %span.item-price-box__tax (税込)
           %span.item-price-box__shipping-fee 送料込み
-          = link_to confirm_items_path, class:"item-buy-btn" do
+          = link_to confirm_item_path, class:"item-buy-btn" do
             購入画面に進む
         .item-description
           .item-description__inner

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
   end
 
   resources :items do
-    collection do
+    member do
       get :confirm
     end
   end


### PR DESCRIPTION
# What
商品購入画面に紐付く商品のデータを表示。

# Why
購入画面から購入機能を実装するため。

<img width="715" alt="01921e1df18b1f4a049c61065e6d45c9" src="https://user-images.githubusercontent.com/57166192/71168306-baf23e80-2299-11ea-9675-26f061b115b2.png">
