### PR TITLE
トップページ turbolinksの修正

### DIFF
--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -3,7 +3,7 @@
     .top.header__box
       .top.header__box__upper
         .top.header__box__upper__title
-          = link_to image_tag("fmarket_logo_red.svg", size: '130x36', alt: "Mercari"), root_path
+          = link_to image_tag("fmarket_logo_red.svg", size: '130x36', alt: "Mercari"), root_path, data: {"turbolinks": false}
         .top.header__box__upper__form
           .top.header__box__upper__form__field
             = form_tag(items_searches_path, local: true, method: :get) do |f|


### PR DESCRIPTION
# What
商品詳細ページのトップページのリンクにturbolinks: falseを追加

# Why
トップページの画像が表示されない為